### PR TITLE
Address scrolling problems on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<title>Ribbon theme for Shower</title>
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
 	<link rel="stylesheet" href="styles/screen-16x10.css">
 </head>
 <body class="shower list">

--- a/styles/slide/slide-full.scss
+++ b/styles/slide/slide-full.scss
@@ -13,7 +13,7 @@
 	position:absolute;
 	top:0;
 	left:0;
-	margin-left:150%;
+	margin-left:-150%;
 	visibility:hidden;
 
 	// Current


### PR DESCRIPTION
- `shrink-to-fit` addresses iOS 9 problems
- setting the left margin to -150% ensures there's nothing to scroll to (Since `visibility: hidden` is used for slides, the actual slide container was hidden, but the contents were still on the screen at 150%. In some occasions, iOS would allow to scroll to them.)

This partly addresses shower/shower#234; the vertical offset problem still occurs every now and then.