### PR TITLE
<mark> should not be used for syntax highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
 	<section class="slide">
 		<h2>Plain Code Listing</h2>
 		<pre><code>&lt;html lang="en"&gt;
-<mark>&lt;head&gt;</mark> <mark class="comment">&lt;!--Comment--&gt;</mark>
+<mark>&lt;head&gt;</mark> <span class="comment">&lt;!--Comment--&gt;</span>
 	&lt;title&gt;Shower&lt;/title&gt;
 	&lt;meta charset="<mark class="important">UTF-8</mark>"&gt;
 	&lt;link rel="stylesheet" href="screen.css"&gt;
@@ -185,7 +185,7 @@
 		<h2>Numbered Code Listing</h2>
 		<pre>
 			<code>&lt;html lang="en"&gt;</code>
-			<code><mark>&lt;head&gt;</mark> <mark class="comment">&lt;!--Comment--&gt;</mark></code>
+			<code><mark>&lt;head&gt;</mark> <span class="comment">&lt;!--Comment--&gt;</span></code>
 			<code>	&lt;title&gt;Shower&lt;/title&gt;</code>
 			<code>	&lt;meta charset="<mark class="important">UTF-8</mark>"&gt;</code>
 			<code>	&lt;link rel="stylesheet" href="screen.css"&gt;</code>
@@ -197,7 +197,7 @@
 		<h2>Highlighted Code Lines</h2>
 		<pre>
 			<code>&lt;html lang="en"&gt;</code>
-			<code class="mark">&lt;head&gt; <mark class="comment">&lt;!--Comment--&gt;</mark></code>
+			<code class="mark">&lt;head&gt; <span class="comment">&lt;!--Comment--&gt;</span></code>
 			<code>	&lt;title&gt;Shower&lt;/title&gt;</code>
 			<code>	&lt;meta charset="<mark class="important">UTF-8</mark>"&gt;</code>
 			<code>	&lt;link rel="stylesheet" href="screen.css"&gt;</code>
@@ -209,7 +209,7 @@
 		<h2>Hidden Code Steps</h2>
 		<pre>
 			<code class="next">&lt;html lang="en"&gt;</code>
-			<code class="next"><mark>&lt;head&gt;</mark> <mark class="comment">&lt;!--Comment--&gt;</mark></code>
+			<code class="next"><mark>&lt;head&gt;</mark> <span class="comment">&lt;!--Comment--&gt;</span></code>
 			<code class="next">	&lt;title&gt;Shower&lt;/title&gt;</code>
 			<code class="next">	&lt;meta charset="<mark class="important">UTF-8</mark>"&gt;</code>
 			<code class="next">	&lt;link rel="stylesheet" href="screen.css"&gt;</code>
@@ -221,7 +221,7 @@
 		<h2>Highlighted Code Steps</h2>
 		<pre>
 			<code class="mark next">&lt;html lang="en"&gt;</code>
-			<code>&lt;head&gt; <mark class="comment">&lt;!--Comment--&gt;</mark></code>
+			<code>&lt;head&gt; <span class="comment">&lt;!--Comment--&gt;</span></code>
 			<code class="mark next">	&lt;title&gt;Shower&lt;/title&gt;</code>
 			<code>	&lt;meta charset="<mark class="important">UTF-8</mark>"&gt;</code>
 			<code class="mark next">	&lt;link rel="stylesheet" href="screen.css"&gt;</code>

--- a/styles/slide/content/code.scss
+++ b/styles/slide/content/code.scss
@@ -69,15 +69,12 @@ pre {
 			color:#FFF;
 			}
 
-		// Comment
+		}
 
-		&.comment {
-			margin:0;
-			padding:0;
-			background:none;
-			color:#999;
-			}
+	// Comment
 
+	.comment {
+		color:#999;
 		}
 
 	}


### PR DESCRIPTION
Comments are syntax highlighting; the `<mark>` element is for references:

> The mark element represents a run of text in one document marked or highlighted **for reference purposes**, due to its relevance in another context.

— https://www.w3.org/TR/html-markup/mark.html

> Do not use the `<mark>` element for syntax highlighting; use the `<span>` element for this purpose.

— https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark

Other usages of `<mark>` in the template are correct, as they are indeed for referencing.