### PR TITLE
Fix progress bar visual bugs in chrome.

### DIFF
--- a/styles/progress/progress-full.scss
+++ b/styles/progress/progress-full.scss
@@ -4,4 +4,5 @@
 
 .progress {
 	display:block;
+	transform: translateZ(0);
 	}


### PR DESCRIPTION
Sometimes there are bugs like this in Chrome.

![Chrome bug](http://i.imgur.com/ioVG3nF.png)

If we use ```translateZ(0)```, we will force Chrome to create a separate layer for this element and those bugs will disappear.