### PR TITLE
Restore compatibility with iOS 8

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,14 @@ gulp.task('styles', () => {
 	return gulp.src('styles/screen-*.scss')
 		.pipe(sass().on('error', sass.logError))
         .pipe(postcss([
-			autoprefixer,
+			autoprefixer({
+				browsers: [
+					'> 1%',
+					'last 2 versions',
+					'Firefox ESR',
+					'iOS >= 8',
+				]
+			}),
 			csso
 		]))
 		.pipe(header(banner, { pkg: pkg }))


### PR DESCRIPTION
Shower stopped working on my iPad; turns out that CSS prefixes for iOS 8 were not included anymore.

This commit extends the default settings of autoprefixer with explicit support for iOS 8.