### PR TITLE
Avoid black screen with invalid slide IDs

### DIFF
--- a/styles/slide/elements/shout-full.scss
+++ b/styles/slide/elements/shout-full.scss
@@ -21,7 +21,7 @@
 
 // Animation Trigger
 
-&:target .shout {
+&.active .shout {
 
 	&.grow,
 	&.shrink {

--- a/styles/slide/slide-full.scss
+++ b/styles/slide/slide-full.scss
@@ -18,7 +18,7 @@
 
 	// Current
 
-	&:target {
+	&.active {
 		margin:0;
 		visibility:visible;
 		}

--- a/styles/slide/slide-list.scss
+++ b/styles/slide/slide-list.scss
@@ -30,7 +30,7 @@
 			0 0 0 20px rgba(black, 0.1),
 			0 20px 50px rgba(black, 0.3);
 		}
-	&:target {
+	&.active {
 		box-shadow:
 			0 0 0 1px darken($blue, 10%),
 			0 0 0 20px $blue,


### PR DESCRIPTION
Links with invalid slide IDs will currently lead to a black screen, because there is no `:target` associated with them.

Unfortunately, this cannot be fixed with JavaScript, as [JavaScript can change the hash, but not `:target`](http://lea.verou.me/2011/05/change-url-hash-without-page-jump/#comment-1993953279).

Therefore, this pull request uses `.active` instead of `:target`. The drawback is that highlighting of the active slide does not work anymore without JavaScript. However, using _both_ `:target` and `.active` is not an option, because this could highlight 2 slides in certain cases.