### PR TITLE
Make live region screen reader friendly

### DIFF
--- a/styles/blocks/region.css
+++ b/styles/blocks/region.css
@@ -7,18 +7,6 @@
     clip: rect(0 0 0 0);
 }
 
-/* List */
-
-.shower.list .region {
-    display: none;
-}
-
-/* Full */
-
-.shower.full .region {
-    display: block;
-}
-
 /* Print */
 
 @media print {


### PR DESCRIPTION
## Live region

In the current `region` implementation screen reader says nothing when changing slides in a grid mode (see screenshot). The problem is gone after removing `display` property of `region` and keeping `visually-hidden` pattern.

![aria-live-display](https://user-images.githubusercontent.com/10166916/44621383-b7b59100-a8a5-11e8-89ac-f680fe37aa8a.gif)
